### PR TITLE
Rename Kind  demo cluster + small improvements

### DIFF
--- a/00-setup-demo/component-repo-src/main-branch/src/flux/helm_release.yaml
+++ b/00-setup-demo/component-repo-src/main-branch/src/flux/helm_release.yaml
@@ -4,7 +4,7 @@ metadata:
   name: podinfo
   namespace: default
 spec:
-  interval: 1m
+  interval: 30s
   chart:
     spec:
       chart: podinfo

--- a/00-setup-demo/component-repo-src/main-branch/src/flux/helm_repository.yaml
+++ b/00-setup-demo/component-repo-src/main-branch/src/flux/helm_repository.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: default
 spec:
   type: "oci"
-  interval: 1m0s
+  interval: 30s
   url: oci://ghcr.io/stefanprodan/charts

--- a/00-setup-demo/component-repo-src/new-release-branch/src/flux/helm_release.yaml
+++ b/00-setup-demo/component-repo-src/new-release-branch/src/flux/helm_release.yaml
@@ -4,7 +4,7 @@ metadata:
   name: podinfo
   namespace: default
 spec:
-  interval: 1m
+  interval: 30s
   chart:
     spec:
       chart: podinfo

--- a/00-setup-demo/component-repo-src/new-release-branch/src/flux/helm_repository.yaml
+++ b/00-setup-demo/component-repo-src/new-release-branch/src/flux/helm_repository.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: default
 spec:
   type: "oci"
-  interval: 1m0s
+  interval: 30s
   url: oci://ghcr.io/stefanprodan/charts

--- a/00-setup-demo/flux-repo-src/main-branch/clusters/kind/components_kustomization.yaml
+++ b/00-setup-demo/flux-repo-src/main-branch/clusters/kind/components_kustomization.yaml
@@ -5,7 +5,7 @@ metadata:
   name: podinfo-component
   namespace: flux-system
 spec:
-  interval: 1m0s
+  interval: 30s
   path: ./components/podinfo
   prune: true
   dependsOn:
@@ -20,7 +20,7 @@ metadata:
   name: weave-gitops-component
   namespace: flux-system
 spec:
-  interval: 1m0s
+  interval: 30s
   path: ./components/weave-gitops
   prune: true
   sourceRef:

--- a/00-setup-demo/flux-repo-src/main-branch/clusters/kind/flux-system/gotk-sync.yaml
+++ b/00-setup-demo/flux-repo-src/main-branch/clusters/kind/flux-system/gotk-sync.yaml
@@ -17,7 +17,7 @@ metadata:
   name: flux-system
   namespace: flux-system
 spec:
-  interval: 10m0s
+  interval: 30s
   path: ./clusters/kind
   prune: true
   sourceRef:

--- a/00-setup-demo/flux-repo-src/main-branch/clusters/kind/subscriptions_kustomization.yaml
+++ b/00-setup-demo/flux-repo-src/main-branch/clusters/kind/subscriptions_kustomization.yaml
@@ -4,7 +4,7 @@ metadata:
   name: subscriptions
   namespace: flux-system
 spec:
-  interval: 1m0s
+  interval: 30s
   path: ./subscriptions
   prune: true
   sourceRef:

--- a/00-setup-demo/flux-repo-src/pr-branch/components/podinfo/component_version.yaml
+++ b/00-setup-demo/flux-repo-src/pr-branch/components/podinfo/component_version.yaml
@@ -4,7 +4,7 @@ metadata:
   name: podinfo
   namespace: ocm-system
 spec:
-  interval: 1m0s
+  interval: 30s
   component: ocm.software/demos/podinfo
   repository:
     url: gitea.ocm.dev/software-consumer

--- a/00-setup-demo/flux-repo-src/pr-branch/components/podinfo/configure.yaml
+++ b/00-setup-demo/flux-repo-src/pr-branch/components/podinfo/configure.yaml
@@ -4,7 +4,7 @@ metadata:
   name: podinfo
   namespace: ocm-system
 spec:
-  interval: 1m0s
+  interval: 30s
   sourceRef:
     kind: Localization
     name: podinfo

--- a/00-setup-demo/flux-repo-src/pr-branch/components/podinfo/deploy.yaml
+++ b/00-setup-demo/flux-repo-src/pr-branch/components/podinfo/deploy.yaml
@@ -8,7 +8,7 @@ spec:
     kind: Configuration
     name: podinfo
   kustomizationTemplate:
-    interval: 1m0s
+    interval: 30s
     path: ./
     prune: true
     targetNamespace: default

--- a/00-setup-demo/flux-repo-src/pr-branch/components/podinfo/localize.yaml
+++ b/00-setup-demo/flux-repo-src/pr-branch/components/podinfo/localize.yaml
@@ -4,7 +4,7 @@ metadata:
   name: podinfo
   namespace: ocm-system
 spec:
-  interval: 1m
+  interval: 30s
   sourceRef:
     kind: ComponentVersion
     name: podinfo

--- a/00-setup-demo/lib.sh
+++ b/00-setup-demo/lib.sh
@@ -11,7 +11,7 @@ function p {
 }
 
 function create-cluster {
-    CLUSTER_NAME=aws-demo
+    CLUSTER_NAME=ocm-demo
     kind create cluster --name $CLUSTER_NAME --config=./kind/config.yaml
     IP=$(docker exec -it $CLUSTER_NAME-control-plane cat /etc/hosts | grep 172.20 | cut -f1)
     docker exec -it $CLUSTER_NAME-control-plane sh -c "echo $IP gitea.ocm.dev >> /etc/hosts"

--- a/00-setup-demo/setup.sh
+++ b/00-setup-demo/setup.sh
@@ -46,7 +46,7 @@ create-cluster
 
 if [ $MODE -eq 1 ]; then
     p "pre-loading images..."
-    preload-images aws-demo
+    preload-images ocm-demo
 fi
 
 p "caching manifests..."

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ run:
 	@./00-setup-demo/setup.sh --offline-mode 1
 
 teardown:
-	kind delete cluster --name aws-demo
+	kind delete cluster --name ocm-demo

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,4 @@ run:
 
 teardown:
 	kind delete cluster --name ocm-demo
+	rm -r 00-setup-demo/charts/telepresence/


### PR DESCRIPTION
- rebrand Kind cluster from aws-demo to ocm-demo
- shorten the interval waiting time to resource reconciliation.